### PR TITLE
Add queue buttons on every load of the watch page

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -53,6 +53,7 @@ $(document).ready(function(){
       }
     }, 3000);
   }
+  addQueueButtonsToSuggestions();
 });
 
 // On page "reload" - youtube is kinda a single page app so


### PR DESCRIPTION
Before, the queue buttons would only appear when a new search was started. Now, they're always attached to whatever's in the suggestion area, even when the page first loads!

I routinely forgot I even had this extension installed until I tried to search for a video from the YouTube search and found it once again to be very convenient. Now the buttons are always there at the ready, increasing their chances to increase your productivity.
